### PR TITLE
Revisions for Python3

### DIFF
--- a/SDK/queueit_knownuserv3/models.py
+++ b/SDK/queueit_knownuserv3/models.py
@@ -87,7 +87,7 @@ class CancelEventConfig:
                 "&ActionName:" + Utils.toString(self.actionName))
 
 
-class KnownUserError(StandardError):
+class KnownUserError(LookupError):
     pass
 
 

--- a/SDK/queueit_knownuserv3/queueit_helpers.py
+++ b/SDK/queueit_knownuserv3/queueit_helpers.py
@@ -1,8 +1,7 @@
 import hmac
 import hashlib
-import urllib
 import time
-import urlparse
+from urllib.parse import urlparse, unquote, quote
 from datetime import datetime, timedelta
 
 
@@ -18,15 +17,15 @@ class QueueitHelpers:
 
     @staticmethod
     def urlEncode(v):
-        return urllib.quote(v, safe='~')
+        return quote(v, safe='~')
 
     @staticmethod
     def urlDecode(v):
-        return urllib.unquote(v)
+        return unquote(v)
 
     @staticmethod
     def urlParse(url_string):
-        return urlparse.urlparse(url_string)
+        return urlparse(url_string)
 
     @staticmethod
     def getCookieExpirationDate():


### PR DESCRIPTION
Looking at https://github.com/queueit/KnownUser.V3.Python/blob/master/SDK/queueit_knownuserv3/user_in_queue_service.py#L7, the claim seems to be that the code should work with Python 3.7, but actually, these further changes are necessary. There are perhaps more.

The README would also need to be updated.

With these changes in place, I was now able to run this:
```shell
$ python3
Python 3.8.10 (default, Jun 22 2022, 20:18:18) 
[GCC 9.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from connector_diagnostics import *
>>> 
```

Before the changes, there were exceptions, eg `'StandardError' is not defined`.